### PR TITLE
Update doc for data-counter in yaml

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ fields:
         label: My Field
         type: text
         attributes:
-            data-counter: ~
+            data-counter: true
             data-max-length: 50
     ...
 ```


### PR DESCRIPTION
Fixes #2 

Finally it's not possible to use `~` as yaml value because the attribute won't be rendered.
